### PR TITLE
Adds or V6 to WAF(Black/White)listRule1 rules

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -637,7 +637,7 @@ resource "aws_wafv2_web_acl" "wafacl" {
         }
         statement {
           ip_set_reference_statement {
-            arn = aws_wafv2_ip_set.WAFWhitelistSetV4.arn
+            arn = aws_wafv2_ip_set.WAFWhitelistSetV6.arn
           }
         }
       }
@@ -666,7 +666,7 @@ resource "aws_wafv2_web_acl" "wafacl" {
         }
         statement {
           ip_set_reference_statement {
-            arn = aws_wafv2_ip_set.WAFBlacklistSetV4.arn
+            arn = aws_wafv2_ip_set.WAFBlacklistSetV6.arn
           }
         }
       }


### PR DESCRIPTION
It seems like WAFBlacklistRule1 and WAFWhitelistRule1 should match on `...listSetV4 or ...listSetV6`(rather than `or ...listSetV4`).

*Issue #, if available:*

*Description of changes:*
Fix or-statement typos

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
